### PR TITLE
Make changes to handle 32/64 build ,

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,25 @@
 
 help:
 	@echo "Makefile for BasicOS Operating System."
-	@echo "Usage: make [ all | dev | stable | clean | distclean | help ] " 
+	@echo "Usage: make [ all | dev | stable | clean | distclean | help ] ARCH = x86 or x86_64" 
 	@echo ""
 	@echo
 
 all:
 	@echo "Building Kernel and ISO!"
+	@mkdir -p bin
 	make -C ./src all
+	./scripts/update_image.sh
 
 dev:
 	@echo "Building Bleeding-Edge Kernel!"
+	@mkdir -p bin
 	make -C ./src dev
-	cp ./src/basicosdev.bin .
 
 stable:
 	@echo "Building Stable Kernel!"
+	@mkdir -p bin
 	make -C ./src stable
-	cp ./src/basicsosstable.bin .
 
 clean:
 	make -C ./src clean

--- a/scripts/update_image.sh
+++ b/scripts/update_image.sh
@@ -13,13 +13,14 @@ fi
 mkdir -p isodir
 mkdir -p isodir/boot
 mkdir -p isodir/boot/grub
-cp src/basicosstable.bin ./isodir/boot/basicosstable.bin
-cp src/basicosdev.bin ./isodir/boot/basicosdev.bin
+echo $PWD
+cp bin/basicosstable.bin ./isodir/boot/basicosstable.bin
+cp bin/basicosdev.bin ./isodir/boot/basicosdev.bin
 cp scripts/menu.lst ./isodir/boot/grub/menu.lst
 cp scripts/stage2_eltorito ./isodir/boot/grub/stage2_eltorito
 if [[ $platform == 'solaris' ]]; then
-        mkisofs -R -b boot/grub/stage2_eltorito -no-emul-boot -boot-load-size 4 -boot-info-table -o basicos.iso isodir
+        mkisofs -R -b boot/grub/stage2_eltorito -no-emul-boot -boot-load-size 4 -boot-info-table -o bin/basicos.iso isodir
 else
-        genisoimage -R -b boot/grub/stage2_eltorito -no-emul-boot -boot-load-size 4 -boot-info-table -o basicos.iso isodir
+        genisoimage -R -b boot/grub/stage2_eltorito -no-emul-boot -boot-load-size 4 -boot-info-table -o bin/basicos.iso isodir
 fi
 rm -r isodir

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,9 @@ STRIP=../cross/os-toolchain/bin/i686-elf-strip
 
 INCLUDE=include/
 LIBDIR=sysroot/lib/
+OBJ_DIR=obj
+BIN_DIR=../bin
+
 CFLAGS=-m32 -std=gnu99 -I$(INCLUDE) -L$(LIBDIR) $(LIBS) -ffreestanding -nostdlib -O2 -Wall -Wextra
 ASFLAGS=-felf32
 LDFLAGS=-T linker.ld
@@ -32,21 +35,108 @@ LDFLAGS=-T linker.ld
 CFLAGS_DEV=-g -std=gnu99 -I$(INCLUDE) -L$(LIBDIR) $(LIBS) -ffreestanding -nostdlib -O2 -Wall -Wextra
 ASFLAGS_DEV=-g -felf32
 
-CSOURCES= ./kernel/arch/x86/io.c ./kernel/common.c ./kernel/vga.c ./kernel/arch/x86/tty.c ./kernel/sample.c ./kernel/arch/x86/gdt.c ./kernel/arch/x86/idt.c ./kernel/arch/x86/panic.c ./kernel/arch/x86/irq.c ./kernel/arch/x86/int.c ./kernel/arch/x86/page.c ./hw/cpu/cpuid.c ./kernel/kernel.c
-ASMSOURCES= ./kernel/arch/x86/boot.s ./kernel/arch/x86/idt_asm.s ./kernel/arch/x86/isr.s ./kernel/test.s
-LIBS=
+ifeq ($(ARCH),x86)
+CSOURCES= 	kernel/arch/x86/io.c \
+		kernel/common.c \
+		kernel/vga.c \
+		kernel/arch/x86/tty.c \
+		kernel/sample.c \
+		kernel/arch/x86/gdt.c \
+		kernel/arch/x86/idt.c \
+		kernel/arch/x86/panic.c \
+		kernel/arch/x86/irq.c \
+		kernel/arch/x86/int.c \
+		kernel/arch/x86/page.c \
+		hw/cpu/cpuid.c \
+		kernel/kernel.c	\
 
-COBJECTS=$(CSOURCES:.c=.o)
-ASMOBJECTS=$(ASMSOURCES:.s=.o)
+ASMSOURCES= 	kernel/arch/x86/boot.s \
+		kernel/arch/x86/idt_asm.s \
+		kernel/arch/x86/isr.s \
+		kernel/test.s	\
 
-CSOURCES_DEV= ./kernel/arch/x86/io.c ./kernel/common.c ./kernel/vga.c ./kernel/arch/x86/tty.c ./kernel/sample.c ./kernel/arch/x86/gdt.c ./kernel/arch/x86/idt.c ./kernel/arch/x86/panic.c ./kernel/arch/x86/irq.c ./kernel/arch/x86/int.c ./kernel/arch/x86/page.c ./hw/cpu/cpuid.c ./kernel/kernel.c
-ASMSOURCES_DEV= ./kernel/arch/x86/boot.s ./kernel/arch/x86/idt_asm.s ./kernel/arch/x86/isr.s ./kernel/test.s
+else ifeq ($(ARCH),x86_64) #64 bit support
+CSOURCES= 	kernel/arch/x86_64/io.c \
+		kernel/common.c kernel/vga.c \
+		kernel/arch/x86_64/tty.c \
+		kernel/sample.c \
+		kernel/arch/x86_64/gdt.c \
+		kernel/arch/x86_64/idt.c \
+		kernel/arch/x86_64/panic.c \
+		kernel/arch/x86_64/irq.c \
+		kernel/arch/x86_64/int.c \
+		kernel/arch/x86_64/page.c \
+		hw/cpu/cpuid.c \
+		kernel/kernel.c	\
 
-COBJECTS_DEV=$(CSOURCES_DEV:.c=.od)
-ASMOBJECTS_DEV=$(ASMSOURCES_DEV:.s=.sod)
+ASMSOURCES= 	kernel/arch/x86_64/boot.s \
+		kernel/arch/x86_64/idt_asm.s \
+		kernel/arch/x86_64/isr.s \
+		kernel/test.s	\
+else #not come here
+endif
 
-KERNEL_DEV=basicosdev.bin
-KERNEL_STABLE=basicosstable.bin
+ifeq ($(ARCH),x86)
+CSOURCES_DEV= 	kernel/arch/x86/io.c \
+		kernel/common.c \
+		kernel/vga.c \
+		kernel/arch/x86/tty.c \
+		kernel/sample.c \
+		kernel/arch/x86/gdt.c \
+		kernel/arch/x86/idt.c \
+		kernel/arch/x86/panic.c \
+		kernel/arch/x86/irq.c \
+		kernel/arch/x86/int.c \
+		kernel/arch/x86/page.c \
+		hw/cpu/cpuid.c \
+		kernel/kernel.c	\
+
+ASMSOURCES_DEV= kernel/arch/x86/boot.s \
+		kernel/arch/x86/idt_asm.s \
+		kernel/arch/x86/isr.s \
+		kernel/test.s	\
+
+else ifeq ($(ARCH),x86_64) #64 bit support
+CSOURCES_DEV= 	kernel/arch/x86_64/io.c \
+		kernel/common.c kernel/vga.c \
+		kernel/arch/x86_64/tty.c \
+		kernel/sample.c \
+		kernel/arch/x86_64/gdt.c \
+		kernel/arch/x86_64/idt.c \
+		kernel/arch/x86_64/panic.c \
+		kernel/arch/x86_64/irq.c \
+		kernel/arch/x86_64/int.c \
+		kernel/arch/x86_64/page.c \
+		hw/cpu/cpuid.c \
+		kernel/kernel.c	\
+
+ASMSOURCES_DEV= kernel/arch/x86_64/boot.s \
+		kernel/arch/x86_64/idt_asm.s \
+		kernel/arch/x86_64/isr.s \
+		kernel/test.s	\
+else #not come here
+endif
+
+KERNEL_DEV=$(BIN_DIR)/basicosdev.bin
+KERNEL_STABLE=$(BIN_DIR)/basicosstable.bin
+
+
+COBJECTS_DEV = $(patsubst %.c,obj/%.od,$(CSOURCES_DEV)) # developer objects named with .od extension
+ASMOBJECTS_DEV = $(patsubst %.s,obj/%.sod,$(ASMSOURCES_DEV))# developer ASM objects named with .sod extension
+
+COBJECTS = $(patsubst %.c,obj/%.os,$(CSOURCES)) # stable objects named with .os extension
+ASMOBJECTS = $(patsubst %.s,obj/%.sos,$(ASMSOURCES))# stable ASM objects named with .os extension
+
+$(COBJECTS_DEV): | obj
+$(ASMOBJECTS_DEV): | obj
+obj:
+	@mkdir -p $@
+
+$(COBJECTS): | obj
+$(ASMOBJECTS): | obj
+obj:
+	@mkdir -p $@
+
 
 all: dev stable
 
@@ -62,15 +152,23 @@ $(KERNEL_STABLE): $(COBJECTS) $(ASMOBJECTS)
 	$(CC) $(LDFLAGS) $(CFLAGS) $(ASMOBJECTS) $(COBJECTS) -o $@
 	$(STRIP) -s -g -v $(KERNEL_STABLE)
 
-%.s.o: %.s
+obj/%.os: %.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+obj/%.sos: %.s
+	@mkdir -p $(@D)
 	$(AS) $(ASFLAGS)  $< -o $@
 
-%.od: %.c
+obj/%.od: %.c
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS_DEV) -c $< -o $@
 
-%.sod: %.s
+obj/%.sod: %.s
+	@mkdir -p $(@D)
 	$(AS) $(ASFLAGS_DEV)  $< -o $@
 
 clean:
-	rm -f $(COBJECTS) $(ASMOBJECTS) $(COBJECTS_DEV) $(ASMOBJECTS_DEV) $(KERNEL_DEV) ../basicos.iso
+	rm -f $(COBJECTS) $(ASMOBJECTS) $(COBJECTS_DEV) $(ASMOBJECTS_DEV) $(KERNEL_DEV) $(BIN_DIR)/basicosdev.bin \
+	$(BIN_DIR)/basicosstable.bin $(BIN_DIR)/basicos.iso
 


### PR DESCRIPTION
seperate obj folder for objects ,
bin folder for bin's and iso
Now clean ,all ,dev must provide ARCH=x86 or x86_64
